### PR TITLE
Handle the case where result data is returned across multiple data events

### DIFF
--- a/lib/timezone.js
+++ b/lib/timezone.js
@@ -43,10 +43,19 @@ var Timezone = function () {
          * @api private
          */
         request = function (options, cb) {
+            var data = '';
             https
                 .get(options, function (res) {
                     res.on('data', function (d) {
-                        return cb(null, JSON.parse(d));
+                        data = data + d;
+                    }).on('error', function(e) {
+                        return cb(e);
+                    }).on('end', function() {
+                        try {
+                            cb(null, JSON.parse(data));
+                        } catch (ex) {
+                            cb(ex);
+                        }
                     });
                 })
                 .on('error', function (e) {


### PR DESCRIPTION
Depending on the exact circumstances of how data is returned from Google maps, multiple data events may be called with parts of the JSON response.  If this occurs, JSON.parse fails with an uncaught exception.  This commit fixes the issue by waiting until all data is received to parse it, and additionally adds an exception handler in the (unlikely) event that the API returns invalid JSON.
